### PR TITLE
Change country codes of "Destination language" options to more meaningful names

### DIFF
--- a/TMessagesProj/src/main/java/ua/itaysonlab/catogram/preferences/ChatsPreferencesEntry.kt
+++ b/TMessagesProj/src/main/java/ua/itaysonlab/catogram/preferences/ChatsPreferencesEntry.kt
@@ -392,29 +392,29 @@ class ChatsPreferencesEntry : BasePreferencesEntry {
 
                 contract({
                     return@contract listOf(
-                            Pair(0, "en"),
-                            Pair(1, "ru"),
-                            Pair(2, "fr"),
-                            Pair(3, "it"),
-                            Pair(4, "es"),
-                            Pair(5, "zh"),
-                            Pair(6, "ja"),
-                            Pair(7, "hi"),
-                            Pair(8, "de"),
-                            Pair(9, "id"),
+                            Pair(0, LocaleController.getString("CG_TrLang_English", R.string.CG_TrLang_English)),
+                            Pair(1, LocaleController.getString("CG_TrLang_Russian", R.string.CG_TrLang_Russian)),
+                            Pair(2, LocaleController.getString("CG_TrLang_French", R.string.CG_TrLang_French)),
+                            Pair(3, LocaleController.getString("CG_TrLang_Italian", R.string.CG_TrLang_Italian)),
+                            Pair(4, LocaleController.getString("CG_TrLang_Spanish", R.string.CG_TrLang_Spanish)),
+                            Pair(5, LocaleController.getString("CG_TrLang_Chinese", R.string.CG_TrLang_Chinese)),
+                            Pair(6, LocaleController.getString("CG_TrLang_Japanese", R.string.CG_TrLang_Japanese)),
+                            Pair(7, LocaleController.getString("CG_TrLang_Hindi", R.string.CG_TrLang_Hindi)),
+                            Pair(8, LocaleController.getString("CG_TrLang_German", R.string.CG_TrLang_German)),
+                            Pair(9, LocaleController.getString("CG_TrLang_Indonesian", R.string.CG_TrLang_Indonesian)),
                     )
                 }, {
                     return@contract when (CatogramConfig.translateOptions) {
-                        1 -> "ru"
-                        2 -> "fr"
-                        3 -> "it"
-                        4 -> "es"
-                        5 -> "zh"
-                        6 -> "ja"
-                        7 -> "hi"
-                        8 -> "de"
-                        9 -> "id"
-                        else -> "en"
+                        1 -> LocaleController.getString("CG_TrLang_Russian", R.string.CG_TrLang_Russian)
+                        2 -> LocaleController.getString("CG_TrLang_French", R.string.CG_TrLang_French)
+                        3 -> LocaleController.getString("CG_TrLang_Italian", R.string.CG_TrLang_Italian)
+                        4 -> LocaleController.getString("CG_TrLang_Spanish", R.string.CG_TrLang_Spanish)
+                        5 -> LocaleController.getString("CG_TrLang_Chinese", R.string.CG_TrLang_Chinese)
+                        6 -> LocaleController.getString("CG_TrLang_Japanese", R.string.CG_TrLang_Japanese)
+                        7 -> LocaleController.getString("CG_TrLang_Hindi", R.string.CG_TrLang_Hindi)
+                        8 -> LocaleController.getString("CG_TrLang_German", R.string.CG_TrLang_German)
+                        9 -> LocaleController.getString("CG_TrLang_Indonesian", R.string.CG_TrLang_Indonesian)
+                        else -> LocaleController.getString("CG_TrLang_English", R.string.CG_TrLang_English)
                     }
                 }) {
                     CatogramConfig.translateOptions = it

--- a/TMessagesProj/src/main/res/values-af/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-af/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-ar/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-ar/cg_strings.xml
@@ -236,6 +236,16 @@
     <string name="CG_SwitchBackend">ستنتقل إلى الخادم التجريبي. من فضلك لا تضغط على \"موافق\" إذا كنت لا تعرف ما تفعله. يمكنك التبديل إلى الخادم العادي بالضغط على \"تبديل الخادم\" في قائمة المعالجة مرة أخرى.</string>
     <string name="CG_SB">تبديل الخادم</string>
     <string name="CG_TrLang">هدف ترجمة اللغة</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">ترجم</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-ca/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-ca/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-cs/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-cs/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-da/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-da/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-de/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-de/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-el/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-el/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-es/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-es/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-fa/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-fa/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-fi/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-fi/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-fr/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-fr/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-he/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-he/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-hi/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-hi/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-hu/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-hu/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-id/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-id/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-it/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-it/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">Stai per spostarti sul server di test. Si prega di non premere OK se non sai cosa stai facendo. Puoi tornare al server normale premendo nuovamente \"Cambia backend\" nel menù di debug.</string>
     <string name="CG_SB">Cambia backend</string>
     <string name="CG_TrLang">Lingua di destinazione</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Traduttore</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-ja/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-ja/cg_strings.xml
@@ -235,6 +235,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-ko/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-ko/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-nl/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-nl/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-no/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-no/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-pl/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-pl/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">Zamierzasz przełączyć się na serwer testowy. Nie naciskaj OK, jeśli nie wiesz, co robisz. Możesz przełączyć się na normalny serwer, naciskając ponownie „Przełącz zaplecze” w menu debugowania.</string>
     <string name="CG_SB">Przełącz zaplecze</string>
     <string name="CG_TrLang">Język docelowy</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Tłumacz</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-pt-rBR/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-pt-rBR/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-ro/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-ro/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-ru/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-ru/cg_strings.xml
@@ -230,6 +230,16 @@
     <string name="CG_Without_Authorship">Без авторства</string>
     <string name="CG_Private">Это приватный канал</string>
     <string name="CG_TrLang">Язык назначения</string>
+    <string name="CG_TrLang_English">Английский</string>
+    <string name="CG_TrLang_Russian">Русский</string>
+    <string name="CG_TrLang_French">Французский</string>
+    <string name="CG_TrLang_Italian">Итальянский</string>
+    <string name="CG_TrLang_Spanish">Испанский</string>
+    <string name="CG_TrLang_Chinese">Китайский</string>
+    <string name="CG_TrLang_Japanese">Японский</string>
+    <string name="CG_TrLang_Hindi">Хинди</string>
+    <string name="CG_TrLang_German">Немецкий</string>
+    <string name="CG_TrLang_Indonesian">Индонезийский</string>
     <string name="CG_Tr">Переводчик</string>
     <string name="CG_Updates_Category">Обновления</string>
     <string name="CG_Auto_Ota">Автоматически искать обновления</string>

--- a/TMessagesProj/src/main/res/values-sr/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-sr/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-sv/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-sv/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-tr/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-tr/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-uk/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-uk/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Автоматично перевіряти оновлення</string>

--- a/TMessagesProj/src/main/res/values-uz/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-uz/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-vi/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-vi/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values-zh/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values-zh/cg_strings.xml
@@ -234,6 +234,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing \"Switch backend\" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>

--- a/TMessagesProj/src/main/res/values/cg_strings.xml
+++ b/TMessagesProj/src/main/res/values/cg_strings.xml
@@ -291,6 +291,16 @@
     <string name="CG_SwitchBackend">You\'re going to switch to the test server. Please don\'t press OK if you don\'t know what you\'re doing. You can switch to normal server by pressing "Switch backend" in debug menu again.</string>
     <string name="CG_SB">Switch backend</string>
     <string name="CG_TrLang">Destination language</string>
+    <string name="CG_TrLang_English">English</string>
+    <string name="CG_TrLang_Russian">Russian</string>
+    <string name="CG_TrLang_French">French</string>
+    <string name="CG_TrLang_Italian">Italian</string>
+    <string name="CG_TrLang_Spanish">Spanish</string>
+    <string name="CG_TrLang_Chinese">Chinese</string>
+    <string name="CG_TrLang_Japanese">Japanese</string>
+    <string name="CG_TrLang_Hindi">Hindi</string>
+    <string name="CG_TrLang_German">German</string>
+    <string name="CG_TrLang_Indonesian">Indonesian</string>
     <string name="CG_Tr">Translator</string>
     <string name="CG_Updates_Category">Updates</string>
     <string name="CG_Auto_Ota">Automatically check for updates</string>


### PR DESCRIPTION
## Description

This PR changes country codes of "Destination language" options to more meaningful ones *(E.g. "en" -> "English")*

> **Note:** This PR only changes names of the options visually and don't affect selection of language *(Selecting a language will return the required country code for the translator anyway)*
>
> Also, needed locale strings has been duplicated in all cg_strings.xml for future translations on Crowdin *(Currently, new locale strings have been translated into Russian)* 


## Example

*Choosing a language for translation before changes:*

<img src="https://user-images.githubusercontent.com/36604233/118342338-91d7eb00-b52b-11eb-97bd-6063d0d333a1.png" height="640px"/>

<hr>

*Choosing a language for translation after changes:*

<img src="https://user-images.githubusercontent.com/36604233/118342351-a0be9d80-b52b-11eb-889e-581bb00e1a02.png" height="640px"/>