### PR TITLE
improving of accessibility of catogram

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -9357,7 +9357,8 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
             }
         }
-        if(currentFocusedVirtualView==-1 &&hasFocus()) announceForAccessibility((progress*100)+"%");
+sendAccessibilityEventForVirtualView(-1,AccessibilityEvent.TYPE_ANNOUNCEMENT    ,(int) (progress*100)+"%");
+
     }
 
     @Override
@@ -9374,7 +9375,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             }
         }
         createLoadingProgressLayout(uploadedSize, totalSize);
-        if(currentFocusedVirtualView==-1 &&hasFocus()) announceForAccessibility((progress*100)+"%");
+        sendAccessibilityEventForVirtualView(-1,AccessibilityEvent.TYPE_ANNOUNCEMENT,(int) (progress*100)+"%");
     }
 
     private void createLoadingProgressLayout(TLRPC.Document document) {
@@ -13606,18 +13607,21 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         return new MessageAccessibilityNodeProvider();
     }
 
-    private void sendAccessibilityEventForVirtualView(int viewId, int eventType) {
+    private void sendAccessibilityEventForVirtualView(int viewId, int eventType,CharSequence text) {
         AccessibilityManager am = (AccessibilityManager) getContext().getSystemService(Context.ACCESSIBILITY_SERVICE);
         if (am.isTouchExplorationEnabled()) {
             AccessibilityEvent event = AccessibilityEvent.obtain(eventType);
             event.setPackageName(getContext().getPackageName());
             event.setSource(ChatMessageCell.this, viewId);
+            if(text!=null) event.getText().add(text);
             if (getParent() != null) {
                 getParent().requestSendAccessibilityEvent(ChatMessageCell.this, event);
             }
         }
     }
-
+    private void sendAccessibilityEventForVirtualView(int viewId, int eventType) {
+sendAccessibilityEventForVirtualView(viewId,eventType,null);
+    }
     public static Point getMessageSize(int imageW, int imageH) {
         return getMessageSize(imageW, imageH, 0, 0);
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -862,7 +862,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             public float getProgress() {
                 if (currentMessageObject.isMusic()) {
                     return seekBar.getProgress();
-                } else if (currentMessageObject.isVoice()) {
+                } else if (currentMessageObject.isVoice() ||currentMessageObject.isRoundVideo()) {
                     if (useSeekBarWaweform) {
                         return seekBarWaveform.getProgress();
                     } else {
@@ -877,7 +877,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             public void setProgress(float progress) {
                 if (currentMessageObject.isMusic()) {
                     seekBar.setProgress(progress);
-                } else if (currentMessageObject.isVoice()) {
+                } else if (currentMessageObject.isVoice() ||currentMessageObject.isRoundVideo()) {
                     if (useSeekBarWaweform) {
                         seekBarWaveform.setProgress(progress);
                     } else {
@@ -9357,6 +9357,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
             }
         }
+        if(currentFocusedVirtualView==-1 &&hasFocus()) announceForAccessibility((progress*100)+"%");
     }
 
     @Override
@@ -9373,6 +9374,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             }
         }
         createLoadingProgressLayout(uploadedSize, totalSize);
+        if(currentFocusedVirtualView==-1 &&hasFocus()) announceForAccessibility((progress*100)+"%");
     }
 
     private void createLoadingProgressLayout(TLRPC.Document document) {
@@ -13530,7 +13532,8 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
 
     @Override
     public boolean performAccessibilityAction(int action, Bundle arguments) {
-        if (action == AccessibilityNodeInfo.ACTION_CLICK) {
+        if(action==AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS) currentFocusedVirtualView=-1;
+        else if (action == AccessibilityNodeInfo.ACTION_CLICK) {
             int icon = getIconForCurrentState();
             if (icon != MediaActionDrawable.ICON_NONE && icon != MediaActionDrawable.ICON_FILE) {
                 didPressButton(true, false);
@@ -13551,7 +13554,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
             }
         }
-        if (currentMessageObject.isVoice() || currentMessageObject.isMusic() && MediaController.getInstance().isPlayingMessage(currentMessageObject)) {
+        if (currentMessageObject.isVoice() ||currentMessageObject.isRoundVideo() || currentMessageObject.isMusic() && MediaController.getInstance().isPlayingMessage(currentMessageObject)) {
             if (seekBarAccessibilityDelegate.performAccessibilityActionInternal(action, arguments)) {
                 return true;
             }
@@ -13572,7 +13575,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
     }
 
     @Override
-    public boolean onHoverEvent(MotionEvent event) {
+    public boolean dispatchHoverEvent(MotionEvent event) {
         int x = (int) event.getX();
         int y = (int) event.getY();
         if (event.getAction() == MotionEvent.ACTION_HOVER_ENTER || event.getAction() == MotionEvent.ACTION_HOVER_MOVE) {
@@ -13588,9 +13591,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
             }
         } else if (event.getAction() == MotionEvent.ACTION_HOVER_EXIT) {
-            currentFocusedVirtualView = 0;
+            currentFocusedVirtualView = -1;
         }
-        return super.onHoverEvent(event);
+        return super.dispatchHoverEvent(event);
     }
 
     @Override
@@ -13979,8 +13982,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.addAction(AccessibilityNodeInfo.ACTION_LONG_CLICK);
                 }
 
-                if ((currentMessageObject.isVoice() || currentMessageObject.isMusic()) && MediaController.getInstance().isPlayingMessage(currentMessageObject)) {
+                if ((currentMessageObject.isVoice() ||currentMessageObject.isRoundVideo() || currentMessageObject.isMusic()) && MediaController.getInstance().isPlayingMessage(currentMessageObject)) {
                     seekBarAccessibilityDelegate.onInitializeAccessibilityNodeInfoInternal(info);
+                }
+                //smallest ids should be added at first,because talkback can focus on it not always in correct order
+                if (forwardedNameLayout[1] != null) {
+                    info.addChild(ChatMessageCell.this, FORWARD);
                 }
 
                 int i;
@@ -14026,9 +14033,6 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
                 if (replyNameLayout != null) {
                     info.addChild(ChatMessageCell.this, REPLY);
-                }
-                if (forwardedNameLayout[0] != null && forwardedNameLayout[1] != null) {
-                    info.addChild(ChatMessageCell.this, FORWARD);
                 }
                 if (drawSelectionBackground || getBackground() != null) {
                     info.setSelected(true);
@@ -14233,14 +14237,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.setClickable(true);
                 } else if (virtualViewId == FORWARD) {
                     info.setEnabled(true);
-                    StringBuilder sb = new StringBuilder();
-                    if (forwardedNameLayout[0] != null && forwardedNameLayout[1] != null) {
-                        for (int a = 0; a < 2; a++) {
-                            sb.append(forwardedNameLayout[a].getText());
-                            sb.append(a == 0 ? " " : "\n");
-                        }
-                    }
-                    info.setContentDescription(sb.toString());
+                    info.setContentDescription(currentForwardNameString);
                     info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
 
                     int x = (int) Math.min(forwardNameX - forwardNameOffsetX[0], forwardNameX - forwardNameOffsetX[1]);
@@ -14256,7 +14253,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.setClassName("android.widget.Button");
                     info.setEnabled(true);
                     if (commentLayout != null) {
-                        info.setText(commentLayout.getText());
+                        //commentLayout not give for us text information about number of comments,so we shouldn't use text of layout for viryual node.
+                        int commentCount=getRepliesCount();
+                        info.setText(isRepliesChat?LocaleController.getString("ViewInChat", R.string.ViewInChat):commentCount == 0 ? LocaleController.getString("LeaveAComment", R.string.LeaveAComment) : LocaleController.formatPluralString("CommentsCount", commentCount));
                     }
                     info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
                     rect.set(commentButtonRect);
@@ -14280,6 +14279,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 performAccessibilityAction(action, arguments);
             } else {
                 if (action == AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS) {
+                    currentFocusedVirtualView=virtualViewId;
                     sendAccessibilityEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
                 } else if (action == AccessibilityNodeInfo.ACTION_CLICK) {
                      if (virtualViewId >= LINK_CAPTION_IDS_START) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DialogCell.java
@@ -3147,7 +3147,6 @@ public class DialogCell extends BaseCell {
     public boolean hasOverlappingRendering() {
         return false;
     }
-
     @Override
     public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
         super.onInitializeAccessibilityNodeInfo(info);
@@ -3156,85 +3155,80 @@ public class DialogCell extends BaseCell {
         } else {
             info.addAction(AccessibilityNodeInfo.ACTION_CLICK);
             info.addAction(AccessibilityNodeInfo.ACTION_LONG_CLICK);
-        }
-    }
-
-    @Override
-    public void onPopulateAccessibilityEvent(AccessibilityEvent event) {
-        super.onPopulateAccessibilityEvent(event);
-        StringBuilder sb = new StringBuilder();
-        if (currentDialogFolderId == 1) {
-            sb.append(LocaleController.getString("ArchivedChats", R.string.ArchivedChats));
-            sb.append(". ");
-        } else {
-            if (encryptedChat != null) {
-                sb.append(LocaleController.getString("AccDescrSecretChat", R.string.AccDescrSecretChat));
+            info.setSelected(checkBox.isChecked());
+            StringBuilder sb = new StringBuilder();
+            if (currentDialogFolderId == 1) {
+                sb.append(LocaleController.getString("ArchivedChats", R.string.ArchivedChats));
                 sb.append(". ");
-            }
-            if (user != null) {
-                if (UserObject.isReplyUser(user)) {
-                    sb.append(LocaleController.getString("RepliesTitle", R.string.RepliesTitle));
-                } else {
-                    if (user.bot) {
-                        sb.append(LocaleController.getString("Bot", R.string.Bot));
-                        sb.append(". ");
-                    }
-                    if (user.self) {
-                        sb.append(LocaleController.getString("SavedMessages", R.string.SavedMessages));
-                    } else {
-                        sb.append(ContactsController.formatName(user.first_name, user.last_name));
-                    }
-                }
-                sb.append(". ");
-            } else if (chat != null) {
-                if (chat.broadcast) {
-                    sb.append(LocaleController.getString("AccDescrChannel", R.string.AccDescrChannel));
-                } else {
-                    sb.append(LocaleController.getString("AccDescrGroup", R.string.AccDescrGroup));
-                }
-                sb.append(". ");
-                sb.append(chat.title);
-                sb.append(". ");
-            }
-        }
-        if (unreadCount > 0) {
-            sb.append(LocaleController.formatPluralString("NewMessages", unreadCount));
-            sb.append(". ");
-        }
-        if (message == null || currentDialogFolderId != 0) {
-            event.setContentDescription(sb.toString());
-            return;
-        }
-        int lastDate = lastMessageDate;
-        if (lastMessageDate == 0) {
-            lastDate = message.messageOwner.date;
-        }
-        String date = LocaleController.formatDateAudio(lastDate, true);
-        if (message.isOut()) {
-            sb.append(LocaleController.formatString("AccDescrSentDate", R.string.AccDescrSentDate, date));
-        } else {
-            sb.append(LocaleController.formatString("AccDescrReceivedDate", R.string.AccDescrReceivedDate, date));
-        }
-        sb.append(". ");
-        if (chat != null && !message.isOut() && message.isFromUser() && message.messageOwner.action == null) {
-            TLRPC.User fromUser = MessagesController.getInstance(currentAccount).getUser(message.messageOwner.from_id.user_id);
-            if (fromUser != null) {
-                sb.append(ContactsController.formatName(fromUser.first_name, fromUser.last_name));
-                sb.append(". ");
-            }
-        }
-        if (encryptedChat == null) {
-            sb.append(message.messageText);
-            if (!message.isMediaEmpty()) {
-                if (!TextUtils.isEmpty(message.caption)) {
+            } else {
+                if (encryptedChat != null) {
+                    sb.append(LocaleController.getString("AccDescrSecretChat", R.string.AccDescrSecretChat));
                     sb.append(". ");
-                    sb.append(message.caption);
+                }
+                if (user != null) {
+                    if (UserObject.isReplyUser(user)) {
+                        sb.append(LocaleController.getString("RepliesTitle", R.string.RepliesTitle));
+                    } else {
+                        if (user.bot) {
+                            sb.append(LocaleController.getString("Bot", R.string.Bot));
+                            sb.append(". ");
+                        }
+                        if (user.self) {
+                            sb.append(LocaleController.getString("SavedMessages", R.string.SavedMessages));
+                        } else {
+                            sb.append(ContactsController.formatName(user.first_name, user.last_name));
+                        }
+                    }
+                    sb.append(". ");
+                } else if (chat != null) {
+                    if (chat.broadcast) {
+                        sb.append(LocaleController.getString("AccDescrChannel", R.string.AccDescrChannel));
+                    } else {
+                        sb.append(LocaleController.getString("AccDescrGroup", R.string.AccDescrGroup));
+                    }
+                    sb.append(". ");
+                    sb.append(chat.title);
+                    sb.append(". ");
                 }
             }
+            if (unreadCount > 0) {
+                sb.append(LocaleController.formatPluralString("NewMessages", unreadCount));
+                sb.append(". ");
+            }
+            if (message == null || currentDialogFolderId != 0) {
+                info.setContentDescription(sb.toString());
+                return;
+            }
+            int lastDate = lastMessageDate;
+            if (lastMessageDate == 0) {
+                lastDate = message.messageOwner.date;
+            }
+            String date = LocaleController.formatDateAudio(lastDate, true);
+            if (message.isOut()) {
+                sb.append(LocaleController.formatString("AccDescrSentDate", R.string.AccDescrSentDate, date));
+            } else {
+                sb.append(LocaleController.formatString("AccDescrReceivedDate", R.string.AccDescrReceivedDate, date));
+            }
+            sb.append(". ");
+            if (chat != null && !message.isOut() && message.isFromUser() && message.messageOwner.action == null) {
+                TLRPC.User fromUser = MessagesController.getInstance(currentAccount).getUser(message.messageOwner.from_id.user_id);
+                if (fromUser != null) {
+                    sb.append(ContactsController.formatName(fromUser.first_name, fromUser.last_name));
+                    sb.append(". ");
+                }
+            }
+            if (encryptedChat == null) {
+                sb.append(message.messageText);
+                if (!message.isMediaEmpty()) {
+                    if (!TextUtils.isEmpty(message.caption)) {
+                        sb.append(". ");
+                        sb.append(message.caption);
+                    }
+                }
+            }
+            info.setContentDescription(sb.toString());
         }
-        event.setContentDescription(sb.toString());
     }
-
     public void setClipProgress(float value) {
         clipProgress = value;
         invalidate();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ProfileSearchCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ProfileSearchCell.java
@@ -677,6 +677,7 @@ public class ProfileSearchCell extends BaseCell {
             builder.append(statusLayout.getText());
         }
         info.setText(builder.toString());
+        info.setSelected(checkBox.isChecked());
     }
 
     public long getDialogId() {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/UserCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/UserCell.java
@@ -504,6 +504,7 @@ public class UserCell extends FrameLayout {
         if (adminTextView != null) {
             adminTextView.setTextColor(Theme.getColor(Theme.key_profile_creatorIcon));
         }
+        if(currentUser!=null &&currentUser.id !=UserConfig.getInstance(currentAccount).getClientUserId() &&currentUser.mutual_contact) statusTextView.setText(statusTextView.getText()+" mutual contact");
     }
 
     public void setSelfAsSavedMessages(boolean value) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/UserCell2.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/UserCell2.java
@@ -291,6 +291,7 @@ public class UserCell2 extends FrameLayout {
             imageView.setVisibility(currentDrawable == 0 ? GONE : VISIBLE);
             imageView.setImageResource(currentDrawable);
         }
+        if(currentUser!=null &&currentUser.id !=UserConfig.getInstance(currentAccount).getClientUserId() &&currentUser.mutual_contact) statusTextView.setText(statusTextView.getText()+" mutual contact");
     }
 
     @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/BotCommandsMenuView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/BotCommandsMenuView.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.text.Layout;
 import android.text.StaticLayout;
 import android.text.TextPaint;
@@ -15,6 +16,7 @@ import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -72,6 +74,18 @@ public class BotCommandsMenuView extends View {
     }
 
     int lastSize;
+
+    @Override
+    public CharSequence getAccessibilityClassName() {
+        return "android.Widget.Button";
+    }
+
+    @Override
+    public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+super.onInitializeAccessibilityNodeInfo(info);
+if(Build.VERSION.SDK_INT>=Build.VERSION_CODES.LOLLIPOP) info.addAction(isOpened()? AccessibilityNodeInfo.ACTION_COLLAPSE:AccessibilityNodeInfo.ACTION_EXPAND);
+info.setContentDescription(LocaleController.getString("AccDescrBotCommands",R.string.AccDescrBotCommands));
+    }
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatGreetingsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatGreetingsView.java
@@ -49,7 +49,7 @@ public class ChatGreetingsView extends LinearLayout {
 
 
         stickerToSendView = new BackupImageView(context);
-
+stickerToSendView.setContentDescription("\uD83D\uDC4B");
         addView(titleView, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 20, 14, 20, 14));
         addView(descriptionView, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 20, 12, 20, 0));
         addView(stickerToSendView, LayoutHelper.createLinear(112, 112, Gravity.CENTER_HORIZONTAL, 0, 16, 0, 16));


### PR DESCRIPTION
In this pull request i did several fixes,connected,in general,with improvements of accessibility of catogram for blind users:

1. Now blind users can know number of comments to some post in channel,without visiting it.
2. Now for acceptDeclineView.java for accessibility action focus i return true,so behaviour of screenreaders (talkback,gieshuo,etc) during the focusing on virtual views will be more correct.
3. some buttons become labeled for blind via contentDescription attribute.
4. Now for chats during pressing with hold blind users will know,whether chat selected or not.
5. Now user can know,whether contact is mutual (if you already have this feature,you can ignore commit,connected with it). I dont know,how to add string to telegram translations,so i desided simple add "mutual contact",instead of creating line in strings.xml.


And other improvements.

# Known issues,which was before my changes:

1. Please record video message. After it you can't play it before sending,because we haven't button for this,as for voice message.
I dont know,whether this possible for sighted people,but if no,it should be implemented for video messages too.
2. Please focus on some video message. You will hear usefull information,including duration of this message,e.g 12 seconds. Please press double tab and focus on it again. Duration will be 11 seconds. So,what information is more correct,before playing,or after starting of the playing. When we close this chat,and open it again,duration of the message not changed,but if we open this chat after very long time,problem repeat again. and this for each video message (only video,not voice,message).
3. I dont know about sighted people,but blind users can't cancel recording of voice/video message,when we drag up,to record message without holding of button. So we should at first stopp recording,and then delete message,because we haven't cancel button to immediately cancel recording of voice/video message.
4. It would be very good,if in channels/groups for blind will be added virtual node,which contains user name (not login in telegram,for example,Саша Козловский). After clicking on this node blind user can know all information about user,such it works,when we click on it in member list of the group. I can do it myself,but i dont understand,how compute coordinates on the screen,which contains user name. If i will get this rect,i can add this node myself.  b