### PR TITLE
accessibility improvements and some fixes

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ArticleViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ArticleViewer.java
@@ -501,6 +501,7 @@ public class ArticleViewer implements NotificationCenter.NotificationCenterDeleg
                 public void onSeekBarDrag(boolean stop, float progress) {
                     int fontSize = Math.round(startFontSize + (endFontSize - startFontSize) * progress);
                     if (fontSize != SharedConfig.ivFontSize) {
+                        sizeBar.getSeekBarAccessibilityDelegate().postAccessibilityEventRunnable(sizeBar);
                         SharedConfig.ivFontSize = fontSize;
                         SharedPreferences preferences = MessagesController.getGlobalMainSettings();
                         SharedPreferences.Editor editor = preferences.edit();

--- a/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
@@ -698,6 +698,7 @@ public class CacheControlActivity extends BaseFragment {
                     view.setBackgroundColor(Theme.getColor(Theme.key_windowBackgroundWhite));
                     SharedPreferences preferences = MessagesController.getGlobalMainSettings();
                     slideChooseView.setCallback(index -> {
+                        slideChooseView.accessibilityDelegate.postAccessibilityEventRunnable(slideChooseView);
                         if (index == 0) {
                             SharedConfig.setKeepMedia(1001);
                         } else if (index == 1) {
@@ -708,7 +709,7 @@ public class CacheControlActivity extends BaseFragment {
                             SharedConfig.setKeepMedia(1);
                         } else if (index == 4) {
                             SharedConfig.setKeepMedia(2);
-                        }
+                                                    }
                     });
                     int keepMedia = SharedConfig.keepMedia;
                     int index;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/BrightnessControlCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/BrightnessControlCell.java
@@ -14,6 +14,7 @@ import android.graphics.PorterDuffColorFilter;
 import android.os.Bundle;
 import android.view.Gravity;
 import android.view.MotionEvent;
+import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -88,6 +89,13 @@ public class BrightnessControlCell extends FrameLayout {
 
     public void setProgress(float value) {
         seekBarView.setProgress(value);
+        seekBarView.getSeekBarAccessibilityDelegate().postAccessibilityEventRunnable(this);
+    }
+
+    @Override
+    public void onInitializeAccessibilityEvent(AccessibilityEvent event) {
+        super.onInitializeAccessibilityEvent(event);
+        seekBarView.getSeekBarAccessibilityDelegate().onInitializeAccessibilityEvent(this,event);
     }
 
     @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -13663,7 +13663,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 return true;
             }
         } else if (event.getAction() == MotionEvent.ACTION_HOVER_EXIT) {
-            //currentFocusedVirtualViewId = -2;
+            currentFocusedVirtualViewId = -2;
         }
         return false;
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ChatMessageCell.java
@@ -897,6 +897,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 onSeekBarDrag(progress);
                 invalidate();
             }
+
         };
         roundVideoPlayingDrawable = new RoundVideoPlayingDrawable(this, resourcesProvider);
     }
@@ -2565,7 +2566,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
             }
             invalidate();
-        }
+                    }
     }
 
     public void setFullyDraw(boolean draw) {
@@ -6420,16 +6421,18 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
         if (currentMessageObject == null) {
             return;
         }
+        seekBarAccessibilityDelegate.postAccessibilityEventRunnable(this);
         currentMessageObject.audioProgress = progress;
         MediaController.getInstance().seekToProgress(currentMessageObject, progress);
         updatePlayingMessageProgress();
-    }
+}
 
     @Override
     public void onSeekBarContinuousDrag(float progress) {
         if (currentMessageObject == null) {
             return;
         }
+seekBarAccessibilityDelegate.postAccessibilityEventRunnable(this);
         currentMessageObject.audioProgress = progress;
         currentMessageObject.audioProgressSec = (int) (currentMessageObject.getDuration() * progress);
         updatePlayingMessageProgress();
@@ -13619,7 +13622,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                 }
             }
         }
-        if (currentMessageObject.isVoice() ||currentMessageObject.isRoundVideo() || currentMessageObject.isMusic() && MediaController.getInstance().isPlayingMessage(currentMessageObject)) {
+        if (isSeekbarCell()) {
             if (seekBarAccessibilityDelegate.performAccessibilityActionInternal(action, arguments)) {
                 return true;
             }
@@ -13638,7 +13641,9 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             onDetachedFromWindow();
         }
     }
-
+    public boolean isSeekbarCell() {
+        return !(buttonState==1 &&loadingProgressLayout!=null) &&(currentMessageObject.isVoice() ||currentMessageObject.isRoundVideo() || currentMessageObject.isMusic());
+    }
     @Override
     public boolean dispatchHoverEvent(MotionEvent event) {
         int x = (int) event.getX();
@@ -13666,6 +13671,12 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
             currentFocusedVirtualViewId = -2;
         }
         return false;
+    }
+
+    @Override
+    public void onInitializeAccessibilityEvent(AccessibilityEvent event) {
+        super.onInitializeAccessibilityEvent(event);
+        if(isSeekbarCell()) seekBarAccessibilityDelegate.onInitializeAccessibilityEvent(this,event);
     }
 
     @Override
@@ -14059,7 +14070,7 @@ public class ChatMessageCell extends BaseCell implements SeekBar.SeekBarDelegate
                     info.addAction(AccessibilityNodeInfo.ACTION_LONG_CLICK);
                 }
 
-                if ((currentMessageObject.isVoice() ||currentMessageObject.isRoundVideo() || currentMessageObject.isMusic()) && MediaController.getInstance().isPlayingMessage(currentMessageObject)) {
+                if (isSeekbarCell()) {
                     seekBarAccessibilityDelegate.onInitializeAccessibilityNodeInfoInternal(info);
                 }
                 //smallest ids should be added at first,because talkback can focus on it not always in correct order

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/MaxFileSizeCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/MaxFileSizeCell.java
@@ -99,6 +99,7 @@ public class MaxFileSizeCell extends FrameLayout {
                         }
                     }
                 }
+                seekBarView.getSeekBarAccessibilityDelegate().postAccessibilityEventRunnable(seekBarView);
                 sizeTextView.setText(LocaleController.formatString("AutodownloadSizeLimitUpTo", R.string.AutodownloadSizeLimitUpTo, AndroidUtilities.formatFileSize(size)));
                 currentSize = size;
                 didChangedSizeValue(size);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ShareDialogCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ShareDialogCell.java
@@ -15,6 +15,7 @@ import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
+import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
@@ -90,6 +91,15 @@ public class ShareDialogCell extends FrameLayout {
             invalidate();
         });
         addView(checkBox, LayoutHelper.createFrame(24, 24, Gravity.CENTER_HORIZONTAL | Gravity.TOP, 19, currentType == TYPE_CREATE ? -40 : 42, 0, 0));
+    }
+
+    @Override
+    public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+        super.onInitializeAccessibilityNodeInfo(info);
+        if(checkBox!=null) {
+            info.setSelected(checkBox.isChecked());
+            info.setClickable(true);
+        }
     }
 
     @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCheckCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCheckCell.java
@@ -272,6 +272,5 @@ public class TextCheckCell extends FrameLayout {
         info.setClassName("android.widget.Switch");
         info.setCheckable(true);
         info.setChecked(checkBox.isChecked());
-        info.setContentDescription(checkBox.isChecked() ? LocaleController.getString("NotificationsOn", R.string.NotificationsOn) : LocaleController.getString("NotificationsOff", R.string.NotificationsOff));
     }
 }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCheckCell2.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/TextCheckCell2.java
@@ -153,6 +153,5 @@ public class TextCheckCell2 extends FrameLayout {
         info.setClassName("android.widget.Switch");
         info.setCheckable(true);
         info.setChecked(checkBox.isChecked());
-        info.setContentDescription(checkBox.isChecked() ? LocaleController.getString("NotificationsOn", R.string.NotificationsOn) : LocaleController.getString("NotificationsOff", R.string.NotificationsOff));
     }
 }

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -2463,6 +2463,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
             TLRPC.UserFull userFull = null;
             if (currentUser != null) {
                 audioCallIconItem = menu.addItem(call, R.drawable.ic_call, themeDelegate);
+audioCallIconItem.setContentDescription(LocaleController.getString("Call",R.string.Call));
                 userFull = getMessagesController().getUserFull(currentUser.id);
                 if (userFull != null && userFull.phone_calls_available) {
                     showAudioCallAsIcon = !inPreviewMode;

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatActivity.java
@@ -1173,7 +1173,7 @@ public class ChatActivity extends BaseFragment implements NotificationCenter.Not
         @Override
         public boolean onItemClick(View view, int position, float x, float y) {
             if (textSelectionHelper.isTryingSelect() || textSelectionHelper.isSelectionMode()) {
-                return false;
+                //return false;
             }
             wasManualScroll = true;
             if (!actionBar.isActionModeShowed() && reportType < 0) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ChatUsersActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ChatUsersActivity.java
@@ -31,6 +31,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.EditText;
 import android.widget.FrameLayout;
@@ -290,6 +291,12 @@ public class ChatUsersActivity extends BaseFragment implements NotificationCente
         }
 
         @Override
+        public void onInitializeAccessibilityEvent(AccessibilityEvent event) {
+            super.onInitializeAccessibilityEvent(event);
+            accessibilityDelegate.onInitializeAccessibilityEvent(this,event);
+        }
+
+        @Override
         public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
             super.onInitializeAccessibilityNodeInfo(info);
             accessibilityDelegate.onInitializeAccessibilityNodeInfoInternal(this, info);
@@ -361,6 +368,7 @@ public class ChatUsersActivity extends BaseFragment implements NotificationCente
             selectedSlowmode = index;
             listViewAdapter.notifyItemChanged(slowmodeInfoRow);
             invalidate();
+            accessibilityDelegate.postAccessibilityEventRunnable(this);
         }
 
         @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AudioPlayerAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AudioPlayerAlert.java
@@ -630,6 +630,7 @@ public class AudioPlayerAlert extends BottomSheet implements NotificationCenter.
             @Override
             public void onSeekBarDrag(boolean stop, float progress) {
                 if (stop) {
+                    seekBarView.getSeekBarAccessibilityDelegate().postAccessibilityEventRunnable(seekBarView    );
                     MediaController.getInstance().seekToProgress(MediaController.getInstance().getPlayingMessageObject(), progress);
                 }
                 MessageObject messageObject = MediaController.getInstance().getPlayingMessageObject();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatGreetingsView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatGreetingsView.java
@@ -51,6 +51,7 @@ public class ChatGreetingsView extends LinearLayout {
 
         stickerToSendView = new BackupImageView(context);
 stickerToSendView.setContentDescription("\uD83D\uDC4B");
+stickerToSendView.setFocusable(true);
         addView(titleView, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 20, 14, 20, 14));
         addView(descriptionView, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 20, 12, 20, 0));
         addView(stickerToSendView, LayoutHelper.createLinear(112, 112, Gravity.CENTER_HORIZONTAL, 0, 16, 0, 16));

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ClearHistoryAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ClearHistoryAlert.java
@@ -341,6 +341,7 @@ public class ClearHistoryAlert extends BottomSheet {
         slideChooseView.setCallback(new SlideChooseView.Callback() {
             @Override
             public void onOptionSelected(int index) {
+                slideChooseView.accessibilityDelegate.postAccessibilityEventRunnable(slideChooseView);
                 newTimer = index;
                 updateTimerButton(true);
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/FloatSeekBarAccessibilityDelegate.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/FloatSeekBarAccessibilityDelegate.java
@@ -2,6 +2,7 @@ package org.telegram.ui.Components;
 
 import android.os.Bundle;
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 
 import androidx.annotation.Nullable;
@@ -60,6 +61,13 @@ public abstract class FloatSeekBarAccessibilityDelegate extends SeekBarAccessibi
         return getProgress() < getMaxValue();
     }
 
+    @Override
+    public void onInitializeAccessibilityEvent(View host, AccessibilityEvent event) {
+        super.onInitializeAccessibilityEvent(host, event);
+        event.setItemCount((int) ((getMaxValue()-getMinValue())*100));
+        event.setCurrentItemIndex((int) (getProgress()*100));
+    }
+
     protected abstract float getProgress();
 
     protected abstract void setProgress(float progress);
@@ -73,6 +81,6 @@ public abstract class FloatSeekBarAccessibilityDelegate extends SeekBarAccessibi
     }
 
     protected float getDelta() {
-        return 0.05f;
+        return 0.01f;
     }
 }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/IntSeekBarAccessibilityDelegate.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/IntSeekBarAccessibilityDelegate.java
@@ -1,6 +1,7 @@
 package org.telegram.ui.Components;
 
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
 
 public abstract class IntSeekBarAccessibilityDelegate extends SeekBarAccessibilityDelegate {
 
@@ -23,6 +24,13 @@ public abstract class IntSeekBarAccessibilityDelegate extends SeekBarAccessibili
         return getProgress() < getMaxValue();
     }
 
+    @Override
+    public void onInitializeAccessibilityEvent(View host, AccessibilityEvent event) {
+        super.onInitializeAccessibilityEvent(host, event);
+        event.setItemCount(getMaxValue()-getMinValue());
+        event.setCurrentItemIndex(getProgress());
+    }
+
     protected abstract int getProgress();
 
     protected abstract void setProgress(int progress);
@@ -31,7 +39,9 @@ public abstract class IntSeekBarAccessibilityDelegate extends SeekBarAccessibili
         return 0;
     }
 
-    protected abstract int getMaxValue();
+    protected  int getMaxValue() {
+        return 100;
+    }
 
     protected int getDelta() {
         return 1;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/NumberPicker.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/NumberPicker.java
@@ -214,6 +214,7 @@ public class NumberPicker extends LinearLayout {
             public CharSequence getContentDescription(View host) {
                 return NumberPicker.this.getContentDescription(mValue);
             }
+
         });
     }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/SeekBarAccessibilityDelegate.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/SeekBarAccessibilityDelegate.java
@@ -43,9 +43,6 @@ public abstract class SeekBarAccessibilityDelegate extends View.AccessibilityDel
     public boolean performAccessibilityActionInternal(@Nullable View host, int action, Bundle args) {
         if (action == AccessibilityNodeInfo.ACTION_SCROLL_FORWARD || action == AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD) {
             doScroll(host, action == AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD);
-            if (host != null) {
-                postAccessibilityEventRunnable(host);
-            }
             return true;
         }
         return false;
@@ -55,7 +52,7 @@ public abstract class SeekBarAccessibilityDelegate extends View.AccessibilityDel
         return performAccessibilityActionInternal(null, action, args);
     }
 
-    private void postAccessibilityEventRunnable(@NonNull View host) {
+    public void postAccessibilityEventRunnable(@NonNull View host) {
         if (!ViewCompat.isAttachedToWindow(host)) {
             return;
         }
@@ -64,9 +61,10 @@ public abstract class SeekBarAccessibilityDelegate extends View.AccessibilityDel
             accessibilityEventRunnables.put(host, runnable = () -> sendAccessibilityEvent(host, AccessibilityEvent.TYPE_VIEW_SELECTED));
             host.addOnAttachStateChangeListener(onAttachStateChangeListener);
         } else {
-            host.removeCallbacks(runnable);
+host.removeCallbacks(runnable);
+host.removeOnAttachStateChangeListener(onAttachStateChangeListener);
         }
-        host.postDelayed(runnable, 400);
+        host.postDelayed(runnable, 200);
     }
 
     @Override
@@ -93,6 +91,12 @@ public abstract class SeekBarAccessibilityDelegate extends View.AccessibilityDel
 
     public final void onInitializeAccessibilityNodeInfoInternal(AccessibilityNodeInfo info) {
         onInitializeAccessibilityNodeInfoInternal(null, info);
+    }
+
+    @Override
+    public void onInitializeAccessibilityEvent(View host, AccessibilityEvent event) {
+        super.onInitializeAccessibilityEvent(host, event);
+        event.setClassName(SEEK_BAR_CLASS_NAME);
     }
 
     protected CharSequence getContentDescription(@Nullable View host) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/SeekBarView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/SeekBarView.java
@@ -59,6 +59,9 @@ public class SeekBarView extends FrameLayout {
         default int getStepsCount() {
             return 0;
         }
+        default int getValueUsingProgress(int startValue,int endValue,float progress) {
+            return Math.round((endValue-startValue)*progress+startValue);
+        }
     }
 
     public SeekBarView(Context context) {
@@ -113,11 +116,12 @@ public class SeekBarView extends FrameLayout {
                 } else {
                     return super.getDelta();
                 }
+
             }
 
             @Override
             public CharSequence getContentDescription(View host) {
-                return delegate != null ? delegate.getContentDescription() : null;
+                 return delegate != null ? delegate.getContentDescription() : null;
             }
         });
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ShareAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ShareAlert.java
@@ -323,6 +323,7 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
             menuIconImageView.setScaleType(ImageView.ScaleType.CENTER);
             menuIconImageView.setImageResource(R.drawable.ic_more_vertical_24);
             menuIconImageView.setColorFilter(new PorterDuffColorFilter(Theme.getColor(Theme.key_dialogSearchIcon), PorterDuff.Mode.MULTIPLY));
+            menuIconImageView.setContentDescription(LocaleController.getString("AccDescrMoreOptions",R.string.AccDescrMoreOptions));
             menuIconImageView.setOnClickListener((v) -> CGFeatureHooks.showForwardMenu(ShareAlert.this, SearchField.this));
 
             addView(menuIconImageView, LayoutHelper.createFrame(36, 36, Gravity.RIGHT | Gravity.TOP, 0, 11, 16, 0));
@@ -335,6 +336,7 @@ public class ShareAlert extends BottomSheet implements NotificationCenter.Notifi
             clearSearchImageView.setScaleY(0.1f);
             clearSearchImageView.setAlpha(0.0f);
             clearSearchImageView.setColorFilter(new PorterDuffColorFilter(getThemedColor(darkTheme ? Theme.key_voipgroup_searchPlaceholder : Theme.key_dialogSearchIcon), PorterDuff.Mode.MULTIPLY));
+            clearSearchImageView.setContentDescription(LocaleController.getString("ClearButton",R.string.ClearButton));
             addView(clearSearchImageView, LayoutHelper.createFrame(36, 36, Gravity.RIGHT | Gravity.TOP, 14, 11, 14, 0));
             clearSearchImageView.setOnClickListener(v -> {
                 updateSearchAdapter = true;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/SlideChooseView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/SlideChooseView.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.text.TextPaint;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 
 import org.telegram.messenger.AndroidUtilities;
@@ -15,7 +16,7 @@ import org.telegram.ui.ActionBar.Theme;
 
 public class SlideChooseView extends View {
 
-    private final SeekBarAccessibilityDelegate accessibilityDelegate;
+    public final SeekBarAccessibilityDelegate accessibilityDelegate;
 
     private Paint paint;
     private Paint linePaint;
@@ -228,6 +229,12 @@ public class SlideChooseView extends View {
     }
 
     @Override
+    public void onInitializeAccessibilityEvent(AccessibilityEvent event) {
+        super.onInitializeAccessibilityEvent(event);
+        accessibilityDelegate.onInitializeAccessibilityEvent(this,event);
+    }
+
+    @Override
     public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
         super.onInitializeAccessibilityNodeInfo(info);
         accessibilityDelegate.onInitializeAccessibilityNodeInfoInternal(this, info);
@@ -246,7 +253,6 @@ public class SlideChooseView extends View {
         Integer color = resourcesProvider != null ? resourcesProvider.getColor(key) : null;
         return color != null ? color : Theme.getColor(key);
     }
-
 
     public interface Callback {
         void onOptionSelected(int index);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/Switch.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/Switch.java
@@ -524,6 +524,5 @@ public class Switch extends View {
         info.setClassName("android.widget.Switch");
         info.setCheckable(true);
         info.setChecked(isChecked);
-        //info.setContentDescription(isChecked ? LocaleController.getString("NotificationsOn", R.string.NotificationsOn) : LocaleController.getString("NotificationsOff", R.string.NotificationsOff));
     }
 }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/voip/AcceptDeclineView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/voip/AcceptDeclineView.java
@@ -582,7 +582,7 @@ if(accessibilityNodeProvider!=null) return accessibilityNodeProvider.dispatchHov
                     return true;
                 }
             } else if (event.getAction() == MotionEvent.ACTION_HOVER_EXIT) {
-                    //  currentFocusedVirtualViewId = -2;
+                     currentFocusedVirtualViewId = -2;
             }
             return false;
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/voip/AcceptDeclineView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/voip/AcceptDeclineView.java
@@ -34,6 +34,7 @@ import org.telegram.messenger.AndroidUtilities;
 import org.telegram.messenger.LocaleController;
 import org.telegram.messenger.R;
 import org.telegram.ui.ActionBar.Theme;
+import org.telegram.ui.Cells.ChatMessageCell;
 
 public class AcceptDeclineView extends View {
 
@@ -50,7 +51,8 @@ public class AcceptDeclineView extends View {
     private AcceptDeclineAccessibilityNodeProvider accessibilityNodeProvider;
 
     private int buttonWidth;
-    private int currentFocusedVirtualViewId = View.NO_ID;
+    private int currentFocusedVirtualViewId =-2;
+    private boolean touch=false;
     float smallRadius;
     float bigRadius;
     boolean expandSmallRadius = true;
@@ -421,15 +423,16 @@ public class AcceptDeclineView extends View {
 
     @Override
     public boolean dispatchHoverEvent(MotionEvent event) {
-        if (accessibilityNodeProvider != null && accessibilityNodeProvider.dispatchHoverEvent(event)) {
-            return true;
-        }
-        return super.dispatchHoverEvent(event);
+if(accessibilityNodeProvider!=null) return accessibilityNodeProvider.dispatchHoverEvent(event); else return super.dispatchHoverEvent(event);
     }
 
     @Override
     public boolean performAccessibilityAction(int action, Bundle arguments) {
         if(action==AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS) currentFocusedVirtualViewId = NO_ID;
+        else if(action==AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS) {
+            if(!touch) currentFocusedVirtualViewId=-2;
+            else touch=false;
+                                }
         return super.performAccessibilityAction(action, arguments);
     }
 
@@ -544,7 +547,7 @@ public class AcceptDeclineView extends View {
 
         @Override
         public boolean performAction(int virtualViewId, int action, Bundle arguments) {
-            if (virtualViewId == HOST_VIEW_ID) {
+            if (virtualViewId == HOST_VIEW_ID ||action==AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS) {
                 return hostView.performAccessibilityAction(action, arguments);
             } else {
                 if (action == AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS) {
@@ -566,30 +569,39 @@ public class AcceptDeclineView extends View {
                     if (rect.contains(x, y)) {
                         if (i != currentFocusedVirtualViewId) {
                             currentFocusedVirtualViewId = i;
+                            touch=true;
                             sendAccessibilityEventForVirtualView(i, AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
                         }
                         return true;
                     }
                 }
-            } else if (event.getAction() == MotionEvent.ACTION_HOVER_EXIT) {
-                if (currentFocusedVirtualViewId != -1   ) {
+                if (currentFocusedVirtualViewId!=-1) {
                     currentFocusedVirtualViewId = -1;
+                    touch=true;
+                    sendAccessibilityEventForVirtualView(-1, AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
                     return true;
                 }
+            } else if (event.getAction() == MotionEvent.ACTION_HOVER_EXIT) {
+                    //  currentFocusedVirtualViewId = -2;
             }
             return false;
         }
 
-        private void sendAccessibilityEventForVirtualView(int virtualViewId, int eventType) {
-            if (accessibilityManager.isTouchExplorationEnabled()) {
-                final ViewParent parent = hostView.getParent();
-                if (parent != null) {
-                    final AccessibilityEvent event = AccessibilityEvent.obtain(eventType);
-                    event.setPackageName(hostView.getContext().getPackageName());
-                    event.setSource(hostView, virtualViewId);
-                    parent.requestSendAccessibilityEvent(hostView, event);
+        private void sendAccessibilityEventForVirtualView(int viewId, int eventType,CharSequence text) {
+            AccessibilityManager am = (AccessibilityManager) getContext().getSystemService(Context.ACCESSIBILITY_SERVICE);
+            if (am.isTouchExplorationEnabled()) {
+                AccessibilityEvent event = AccessibilityEvent.obtain(eventType);
+                event.setPackageName(getContext().getPackageName());
+                event.setSource(AcceptDeclineView.this, viewId);
+                if(text!=null) event.getText().add(text);
+                if (getParent() != null) {
+                    getParent().requestSendAccessibilityEvent(AcceptDeclineView.this, event);
                 }
             }
+        }
+
+        private void sendAccessibilityEventForVirtualView(int viewId, int eventType) {
+            sendAccessibilityEventForVirtualView(viewId,eventType,null);
         }
 
         protected abstract CharSequence getVirtualViewText(int virtualViewId);

--- a/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PhotoViewer.java
@@ -421,7 +421,55 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
             }
         }
     };
+private final VideoPlayerSeekBar.SeekBarDelegate seekBarDelegate = new VideoPlayerSeekBar.SeekBarDelegate() {
+        @Override
+        public void onSeekBarDrag(float progress) {
+                        if (videoPlayer != null) {
+                            accessibilityDelegate.postAccessibilityEventRunnable(videoPlayerSeekbarView);
+                if (!inPreview && videoTimelineView.getVisibility() == View.VISIBLE) {
+                    progress = videoTimelineView.getLeftProgress() + (videoTimelineView.getRightProgress() - videoTimelineView.getLeftProgress()) * progress;
+                }
+                long duration = videoPlayer.getDuration();
+                if (duration == C.TIME_UNSET) {
+                    seekToProgressPending = progress;
+                } else {
+                    videoPlayer.seekTo((int) (progress * duration));
+                }
+                showVideoSeekPreviewPosition(false);
+                needShowOnReady = false;
+            }
+        }
 
+        @Override
+        public void onSeekBarContinuousDrag(float progress) {
+            if (videoPlayer != null && videoPreviewFrame != null) {
+                videoPreviewFrame.setProgress(progress, videoPlayerSeekbar.getWidth());
+            }
+            accessibilityDelegate.postAccessibilityEventRunnable(videoPlayerSeekbarView);
+            showVideoSeekPreviewPosition(true);
+            updateVideoSeekPreviewPosition();
+        }
+    };
+    final FloatSeekBarAccessibilityDelegate accessibilityDelegate = new FloatSeekBarAccessibilityDelegate() {
+        @Override
+        public float getProgress() {
+            return videoPlayerSeekbar.getProgress();
+        }
+
+        @Override
+        public void setProgress(float progress) {
+            seekBarDelegate.onSeekBarDrag(progress);
+            videoPlayerSeekbar.setProgress(progress);
+            videoPlayerSeekbarView.invalidate();
+        }
+
+        @Override
+        public String getContentDescription(View host) {
+            final String time = LocaleController.formatPluralString("Minutes", videoPlayerCurrentTime[0]) + ' ' + LocaleController.formatPluralString("Seconds", videoPlayerCurrentTime[1]);
+            final String totalTime = LocaleController.formatPluralString("Minutes", videoPlayerTotalTime[0]) + ' ' + LocaleController.formatPluralString("Seconds", videoPlayerTotalTime[1]);
+            return LocaleController.formatString("AccDescrPlayerDuration", R.string.AccDescrPlayerDuration, time, totalTime);
+        }
+    };
     private AspectRatioFrameLayout aspectRatioFrameLayout;
     private View flashView;
     private AnimatorSet flashAnimator;
@@ -6430,55 +6478,6 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
     private void createVideoControlsInterface() {
         videoPlayerControlFrameLayout = new VideoPlayerControlFrameLayout(containerView.getContext());
         containerView.addView(videoPlayerControlFrameLayout, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 48, Gravity.BOTTOM | Gravity.LEFT));
-
-        final VideoPlayerSeekBar.SeekBarDelegate seekBarDelegate = new VideoPlayerSeekBar.SeekBarDelegate() {
-            @Override
-            public void onSeekBarDrag(float progress) {
-                if (videoPlayer != null) {
-                    if (!inPreview && videoTimelineView.getVisibility() == View.VISIBLE) {
-                        progress = videoTimelineView.getLeftProgress() + (videoTimelineView.getRightProgress() - videoTimelineView.getLeftProgress()) * progress;
-                    }
-                    long duration = videoPlayer.getDuration();
-                    if (duration == C.TIME_UNSET) {
-                        seekToProgressPending = progress;
-                    } else {
-                        videoPlayer.seekTo((int) (progress * duration));
-                    }
-                    showVideoSeekPreviewPosition(false);
-                    needShowOnReady = false;
-                }
-            }
-
-            @Override
-            public void onSeekBarContinuousDrag(float progress) {
-                if (videoPlayer != null && videoPreviewFrame != null) {
-                    videoPreviewFrame.setProgress(progress, videoPlayerSeekbar.getWidth());
-                }
-                showVideoSeekPreviewPosition(true);
-                updateVideoSeekPreviewPosition();
-            }
-        };
-
-        final FloatSeekBarAccessibilityDelegate accessibilityDelegate = new FloatSeekBarAccessibilityDelegate() {
-            @Override
-            public float getProgress() {
-                return videoPlayerSeekbar.getProgress();
-            }
-
-            @Override
-            public void setProgress(float progress) {
-                seekBarDelegate.onSeekBarDrag(progress);
-                videoPlayerSeekbar.setProgress(progress);
-                videoPlayerSeekbarView.invalidate();
-            }
-
-            @Override
-            public String getContentDescription(View host) {
-                final String time = LocaleController.formatPluralString("Minutes", videoPlayerCurrentTime[0]) + ' ' + LocaleController.formatPluralString("Seconds", videoPlayerCurrentTime[1]);
-                final String totalTime = LocaleController.formatPluralString("Minutes", videoPlayerTotalTime[0]) + ' ' + LocaleController.formatPluralString("Seconds", videoPlayerTotalTime[1]);
-                return LocaleController.formatString("AccDescrPlayerDuration", R.string.AccDescrPlayerDuration, time, totalTime);
-            }
-        };
         videoPlayerSeekbarView = new View(containerView.getContext()) {
             @Override
             protected void onDraw(Canvas canvas) {
@@ -9583,6 +9582,9 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
         }
     }
 
+    private boolean isVideo(final int index) {
+return currentMessageObject != null && currentMessageObject.isVideo() || currentBotInlineResult != null && (currentBotInlineResult.type.equals("video") || MessageObject.isVideoDocument(currentBotInlineResult.document)) || pageBlocksAdapter != null && pageBlocksAdapter.isVideo(index);
+    }
     private void onPhotoShow(final MessageObject messageObject, final TLRPC.FileLocation fileLocation, ImageLocation imageLocation, ImageLocation videoLocation, final ArrayList<MessageObject> messages, final ArrayList<SecureDocument> documents, final List<Object> photos, int index, final PlaceProviderObject object) {
         classGuid = ConnectionsManager.generateClassGuid();
         currentMessageObject = null;
@@ -9970,7 +9972,7 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
                 MessagesController.getInstance(currentAccount).loadDialogPhotos(avatarsDialogId, 80, 0, true, classGuid);
             }
         }
-        if (currentMessageObject != null && currentMessageObject.isVideo() || currentBotInlineResult != null && (currentBotInlineResult.type.equals("video") || MessageObject.isVideoDocument(currentBotInlineResult.document)) || pageBlocksAdapter != null && pageBlocksAdapter.isVideo(index)) {
+        if (isVideo(index)) {
             playerAutoStarted = true;
             onActionClick(false);
         } else if (!imagesArrLocals.isEmpty()) {
@@ -12406,7 +12408,8 @@ public class PhotoViewer implements NotificationCenter.NotificationCenterDelegat
         }
 
         AccessibilityManager am = (AccessibilityManager) parentActivity.getSystemService(Context.ACCESSIBILITY_SERVICE);
-        if (am.isTouchExplorationEnabled()) {
+        //Check,whether we open photo,or play video. If photo,announce about it. May be exists more correct way to check,what we open now?
+        if (am.isTouchExplorationEnabled() &&!isVideo(index) &&(currentMessageObject!=null &&currentMessageObject.isPhoto() ||currentMessageObject==null &&(!imagesArrLocals.isEmpty() ||videoLocation ==null))) {
             AccessibilityEvent event = AccessibilityEvent.obtain();
             event.setEventType(AccessibilityEvent.TYPE_ANNOUNCEMENT);
             event.getText().add(LocaleController.getString("AccDescrPhotoViewer", R.string.AccDescrPhotoViewer));

--- a/TMessagesProj/src/main/java/org/telegram/ui/ThemeActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ThemeActivity.java
@@ -34,6 +34,7 @@ import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.Button;
 import android.widget.FrameLayout;
@@ -239,8 +240,9 @@ public class ThemeActivity extends BaseFragment implements NotificationCenter.No
             sizeBar.setDelegate(new SeekBarView.SeekBarViewDelegate() {
                 @Override
                 public void onSeekBarDrag(boolean stop, float progress) {
-                    setFontSize(Math.round(startFontSize + (endFontSize - startFontSize) * progress));
-                }
+                    sizeBar.getSeekBarAccessibilityDelegate().postAccessibilityEventRunnable(TextSizeCell.this);
+                    setFontSize(getValueUsingProgress(startFontSize,endFontSize,progress));
+                 }
 
                 @Override
                 public void onSeekBarPressed(boolean pressed) {
@@ -248,12 +250,12 @@ public class ThemeActivity extends BaseFragment implements NotificationCenter.No
 
                 @Override
                 public CharSequence getContentDescription() {
-                    return String.valueOf(Math.round(startFontSize + (endFontSize - startFontSize) * sizeBar.getProgress()));
+                    return String.valueOf(getValueUsingProgress(startFontSize,endFontSize,sizeBar.getProgress()));
                 }
 
                 @Override
                 public int getStepsCount() {
-                    return endFontSize - startFontSize;
+                    return endFontSize-startFontSize;
                 }
             });
             sizeBar.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
@@ -290,6 +292,12 @@ public class ThemeActivity extends BaseFragment implements NotificationCenter.No
         }
 
         @Override
+        public void onInitializeAccessibilityEvent(AccessibilityEvent event) {
+            super.onInitializeAccessibilityEvent(event);
+            sizeBar.getSeekBarAccessibilityDelegate().onInitializeAccessibilityEvent(this,event);
+        }
+
+        @Override
         public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
             super.onInitializeAccessibilityNodeInfo(info);
             sizeBar.getSeekBarAccessibilityDelegate().onInitializeAccessibilityNodeInfoInternal(this, info);
@@ -322,7 +330,8 @@ public class ThemeActivity extends BaseFragment implements NotificationCenter.No
             sizeBar.setDelegate(new SeekBarView.SeekBarViewDelegate() {
                 @Override
                 public void onSeekBarDrag(boolean stop, float progress) {
-                    setBubbleRadius(Math.round(startRadius + (endRadius - startRadius) * progress), false);
+                    sizeBar.getSeekBarAccessibilityDelegate().postAccessibilityEventRunnable(BubbleRadiusCell.this);
+                    setBubbleRadius(getValueUsingProgress(startRadius,endRadius,progress), false);
                 }
 
                 @Override
@@ -331,12 +340,12 @@ public class ThemeActivity extends BaseFragment implements NotificationCenter.No
 
                 @Override
                 public CharSequence getContentDescription() {
-                    return String.valueOf(Math.round(startRadius + (endRadius - startRadius) * sizeBar.getProgress()));
+                    return String.valueOf(getValueUsingProgress(startRadius,endRadius,sizeBar.getProgress()));
                 }
 
                 @Override
                 public int getStepsCount() {
-                    return endRadius - startRadius;
+return endRadius-startRadius;
                 }
             });
             sizeBar.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
@@ -359,6 +368,12 @@ public class ThemeActivity extends BaseFragment implements NotificationCenter.No
         public void invalidate() {
             super.invalidate();
             sizeBar.invalidate();
+        }
+
+        @Override
+        public void onInitializeAccessibilityEvent(AccessibilityEvent event) {
+            super.onInitializeAccessibilityEvent(event);
+            sizeBar.getSeekBarAccessibilityDelegate().onInitializeAccessibilityEvent(this, event);
         }
 
         @Override

--- a/TMessagesProj/src/main/java/org/telegram/ui/ThemePreviewActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ThemePreviewActivity.java
@@ -1779,6 +1779,7 @@ public class ThemePreviewActivity extends BaseFragment implements DownloadContro
                         intensitySeekBar.setDelegate(new SeekBarView.SeekBarViewDelegate() {
                             @Override
                             public void onSeekBarDrag(boolean stop, float progress) {
+                                intensitySeekBar.getSeekBarAccessibilityDelegate().postAccessibilityEventRunnable(intensitySeekBar);
                                 currentIntensity = progress;
                                 backgroundImage.getImageReceiver().setAlpha(Math.abs(currentIntensity));
                                 backgroundImage.invalidate();


### PR DESCRIPTION
In this pr i suggest some fixes and improvements for blind users,to improve accessibility of catogram.
1. Now title/summary of all switches will be read by talkback and probably by other screenreaders.
2. Now fixed situation,when if message was selected and blind users hold it,selection not cancel (chatActivity.java).
3. Rewrited handling of touching for blind users.
4. Now screenreaders will announce progress only if it focused on the message.